### PR TITLE
make it usable as installable cmdline tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "crypto-js": "^4.1.1",
         "node-fetch": "^3.1.0",
         "terminal-kit": "^2.3.0"
+      },
+      "bin": {
+        "node-anime": "src/index.js"
       }
     },
     "node_modules/@cronvel/get-pixels": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "node-fetch": "^3.1.0",
     "terminal-kit": "^2.3.0"
   },
+  "bin": "src/index.js",
   "repository": "github:MeemeeLab/node-anime",
   "homepage": "https://github.com/MeemeeLab/node-anime#readme"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import anime from './modules/anime.js';
 import child_process from 'child_process';
 import Terminal from 'terminal-kit';

--- a/src/modules/interface.js
+++ b/src/modules/interface.js
@@ -1,8 +1,8 @@
 import Terminal from "terminal-kit";
+import path from 'path'
 import {readFileSync} from "fs";
 
-const config = JSON.parse(readFileSync("package.json"));
-
+const config = JSON.parse(readFileSync(path.posix.dirname(import.meta.url).substr(7) + '/../../package.json'))
 export default class Interface {
     term;
     cb;


### PR DESCRIPTION
`npm i -g asdfugil/node-anime`

Tool will be available as command `node-anime`

also this does not seem to be licensed